### PR TITLE
README.rst: Simplify example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,23 +7,32 @@ In your ``appveyor.yml`` file, specify the different builds like this:
 
     environment:
       matrix:
+        # Python 2.7, 64-bit
+        - TOXENV: "py27"
+          TOX_APPVEYOR_X64: 1
+
+        # Python 2.7, 32-bit
+        - TOXENV: "py27"
+          TOX_APPVEYOR_X64: 0
+
         # Python 3.7, 64-bit
         - TOXENV: "py37"
-          TOX_APPVEYOR_X64=1
+          TOX_APPVEYOR_X64: 1
 
         # Python 3.7, 32-bit
         - TOXENV: "py37"
-          TOX_APPVEYOR_X64=0
+          TOX_APPVEYOR_X64: 0
 
+    build: off
 
     # For the sections below, the Python version doesn't matter:
     # tox will make an environment based on the environment variables.
 
     install:
-      - "build.cmd py -3.6 -m pip install wheel tox tox-appveyor"
+      - "py -3.6 -m pip install wheel tox tox-appveyor"
 
     test_script:
-      - "build.cmd py -3.6 -m tox"
+      - "py -3.6 -m tox"
 
 `Supporting Windows using Appveyor <https://packaging.python.org/guides/supporting-windows-using-appveyor/#testing-with-tox>`_
 in the Python Packaging User Guide has more background info about testing Python


### PR DESCRIPTION
The example should be as easy as possible.
Remove use of optional build.cmd, and
also fixes syntax error in envvars.